### PR TITLE
add Content-Length to requests with a body

### DIFF
--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -342,7 +342,9 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget {
     if( body instanceof Uint8Array || body instanceof ArrayBuffer ) {
       body = Buffer.from(body);
     }
-    if (typeof body === 'string' || body instanceof Buffer || body instanceof FormData) {      client.on('socket', _setDispatchProgressEvents.bind(this.upload));
+    if (typeof body === 'string' || Buffer.isBuffer(body) || body instanceof FormData) {
+      client.setHeader('Content-Length', Buffer.isBuffer(body) ? body.length : Buffer.byteLength(body));
+      client.on('socket', _setDispatchProgressEvents.bind(this.upload));
       client.write(body);
     }
     client.end();


### PR DESCRIPTION
Some servers do not accept unbounded requests. Add the Content-Length header to rectify