### PR TITLE
delint

### DIFF
--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -339,10 +339,11 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget {
       client.setHeader(key, value);
     });
     _readyStateChange.call(this, XMLHttpRequest.HEADERS_RECEIVED);
-    if( body instanceof Uint8Array || body instanceof ArrayBuffer ) {
+    if ( body instanceof Uint8Array || body instanceof ArrayBuffer ) {
       body = Buffer.from(body);
     }
-    if (typeof body === 'string' || body instanceof Buffer || body instanceof FormData) {      client.on('socket', _setDispatchProgressEvents.bind(this.upload));
+    if (typeof body === 'string' || body instanceof Buffer || body instanceof FormData) {
+      client.on('socket', _setDispatchProgressEvents.bind(this.upload));
       client.write(body);
     }
     client.end();


### PR DESCRIPTION
```
node-xmlhttprequest/lib/xmlhttprequest.js
  342:7   error  Keyword "if" must be followed by whitespace              space-after-keywords
  345:96  error  Multiple spaces found before 'client'                    no-multi-spaces
  345:96  error  Statement inside of curly braces should be on next line  brace-style
```

fixed