### PR TITLE
Fix lint error

### DIFF
--- a/lib/xmlhttprequest.js
+++ b/lib/xmlhttprequest.js
@@ -339,7 +339,7 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget {
       client.setHeader(key, value);
     });
     _readyStateChange.call(this, XMLHttpRequest.HEADERS_RECEIVED);
-    if( body instanceof Uint8Array || body instanceof ArrayBuffer ) {
+    if ( body instanceof Uint8Array || body instanceof ArrayBuffer ) {
       body = Buffer.from(body);
     }
     if (typeof body === 'string' || Buffer.isBuffer(body) || body instanceof FormData) {


### PR DESCRIPTION
```
/Users/stux/git/node-xmlhttprequest/lib/xmlhttprequest.js
  342:7  error  Keyword "if" must be followed by whitespace  space-after-keywords

✖ 1 problem (1 error, 0 warnings)
```

Fixed.